### PR TITLE
Rename update functions

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -59,7 +59,7 @@ public func routes(_ router: Router) throws {
         return getSimulation(on: req).flatMap(to: View.self) { simulation in
             if simulation.simulationShouldUpdate(currentDate: Date()) {
                 return Player.query(on: req).all().flatMap(to: View.self) { players in
-                    let result = simulation.update(currentDate: Date(), players: players)
+                    let result = simulation.updateSimulation(currentDate: Date(), players: players)
                     assert(simulation.id != nil)
                     assert(result.updatedSimulation.id != nil)
                     assert(simulation.id == result.updatedSimulation.id)

--- a/Sources/Model/Improvement.swift
+++ b/Sources/Model/Improvement.swift
@@ -14,7 +14,7 @@ struct Improvement: Content {
     public let name: String
     public let ownerID: UUID
     
-    func update() -> Improvement {
+    func updateImprovement() -> Improvement {
         return self
     }
 }

--- a/Sources/Model/Player.swift
+++ b/Sources/Model/Player.swift
@@ -60,7 +60,7 @@ public struct Player: Content, SQLiteUUIDModel {
         self.username = username
     }
     
-    public func update(ticks: Int = 1) -> Player {
+    public func updatePlayer(ticks: Int = 1) -> Player {
         var updatedPlayer = self
         
         for _ in 0 ..< ticks {

--- a/Sources/Model/Simulation.swift
+++ b/Sources/Model/Simulation.swift
@@ -32,7 +32,7 @@ public struct Simulation {
         self.nextUpdateDate = nextUpdateDate
     }
     
-    public func update(currentDate: Date, players: [Player]) -> (updatedSimulation: Simulation, updatedPlayers: [Player]) {
+    public func updateSimulation(currentDate: Date, players: [Player]) -> (updatedSimulation: Simulation, updatedPlayers: [Player]) {
         var updatedSimulation = self
         var updatedPlayers = players
     
@@ -43,7 +43,7 @@ public struct Simulation {
             let tickCount = updatedSimulation.tickCount + 1
             
             updatedPlayers = updatedPlayers.map { player in
-                player.update()
+                player.updatePlayer()
             }
             
             updatedSimulation = Simulation(id: self.id, tickCount: tickCount, gameDate: gameDate, nextUpdateDate: nextUpdateDate)

--- a/Tests/AppTests/PerformanceTests.swift
+++ b/Tests/AppTests/PerformanceTests.swift
@@ -90,7 +90,7 @@ final class PerformanceTests: XCTestCase {
         let maxSteps = 1_000_000
         var steps = 0
         while mission.percentageDone < 100 && steps < maxSteps {
-            player = player.update()
+            player = player.updatePlayer()
             let investment = try player.investInMission(amount: player.cash, in: mission)
             player = investment.changedPlayer
             mission = investment.changedMission

--- a/Tests/AppTests/PlayerDBTests.swift
+++ b/Tests/AppTests/PlayerDBTests.swift
@@ -69,7 +69,7 @@ final class PlayerDBTests : XCTestCase {
     
     func testSaveUpdatedPlayer() throws {
         let player = try createTestPlayer()
-        let updatedPlayer = player.update()
+        let updatedPlayer = player.updatePlayer()
         let savedPlayer = try app!.withPooledConnection(to: .sqlite) { conn -> Future<Player> in
             return updatedPlayer.save(on: conn)
         }.wait()

--- a/Tests/AppTests/PlayerTests.swift
+++ b/Tests/AppTests/PlayerTests.swift
@@ -15,7 +15,7 @@ final class PlayerTests : XCTestCase {
     func testUpdatePlayer() throws {
         let player = Player(username: "testUser")
         
-        let updatedPlayer = player.update()
+        let updatedPlayer = player.updatePlayer()
         
         XCTAssertGreaterThan(updatedPlayer.cash, player.cash, " cash")
         XCTAssertGreaterThan(updatedPlayer.technologyPoints, player.technologyPoints, " cash")

--- a/Tests/AppTests/SimulationDBTests.swift
+++ b/Tests/AppTests/SimulationDBTests.swift
@@ -77,7 +77,7 @@ final class SimulationDBTests : XCTestCase {
         XCTAssertEqual(loadedSimulations.count, 1)
         let loadedSimulation = loadedSimulations.first!
         
-        let result = loadedSimulation.update(currentDate: Date(), players: players)
+        let result = loadedSimulation.updateSimulation(currentDate: Date(), players: players)
         XCTAssertEqual(result.updatedSimulation.id, loadedSimulation.id, "UUID should be unchanged after update.")
         
         for i in 0 ..< players.count {
@@ -93,7 +93,7 @@ final class SimulationDBTests : XCTestCase {
         }).wait()
         
         let updatedPlayers = players.map { player in
-            player.update()
+            player.updatePlayer()
         }
         
         _ = try app!.withPooledConnection(to: .sqlite, closure: { conn -> Future<[Player]> in
@@ -122,7 +122,7 @@ final class SimulationDBTests : XCTestCase {
         
         let loadedSimulation = loadedSimulations.first!
         
-        let result = loadedSimulation.update(currentDate: Date(), players: [])
+        let result = loadedSimulation.updateSimulation(currentDate: Date(), players: [])
         
         let savedSimulation = try app!.withPooledConnection(to: .sqlite) { conn in
             return result.updatedSimulation.update(on: conn)

--- a/Tests/AppTests/SimulationTests.swift
+++ b/Tests/AppTests/SimulationTests.swift
@@ -16,7 +16,7 @@ final class SimulationTests : XCTestCase {
         let gameDate = Date().addingTimeInterval(24*60*60*365)
         
         let simulation = Simulation(tickCount: 0, gameDate: gameDate, nextUpdateDate: Date())
-        let update = simulation.update(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60), players: [])
+        let update = simulation.updateSimulation(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60), players: [])
         
         XCTAssertGreaterThan(update.updatedSimulation.tickCount, simulation.tickCount, " ticks")
         XCTAssertGreaterThan(update.updatedSimulation.gameDate, simulation.gameDate, " gameDate")
@@ -29,7 +29,7 @@ final class SimulationTests : XCTestCase {
         let gameDate = Date().addingTimeInterval(24*60*60*365)
         
         let simulation = Simulation(tickCount: 0, gameDate: gameDate, nextUpdateDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60))
-        let update = simulation.update(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 30), players: [])
+        let update = simulation.updateSimulation(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 30), players: [])
         
         XCTAssertEqual(update.updatedSimulation.tickCount, simulation.tickCount, " ticks")
         XCTAssertEqual(update.updatedSimulation.gameDate, simulation.gameDate, " gameDate")
@@ -41,7 +41,7 @@ final class SimulationTests : XCTestCase {
         let gameDate = Date().addingTimeInterval(24*60*60*365)
         
         let simulation = Simulation(tickCount: 0, gameDate: gameDate, nextUpdateDate: Date())
-        let update = simulation.update(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60 * 4), players: [])
+        let update = simulation.updateSimulation(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60 * 4), players: [])
         
         XCTAssertEqual(update.updatedSimulation.tickCount, 5, " ticks")
     }
@@ -52,7 +52,7 @@ final class SimulationTests : XCTestCase {
         let players = [Player(username: "testUser")]
         
         let simulation = Simulation(tickCount: 0, gameDate: gameDate, nextUpdateDate: Date())
-        let update = simulation.update(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60 * 4), players: players)
+        let update = simulation.updateSimulation(currentDate: Date().addingTimeInterval(Simulation.UPDATE_INTERVAL_IN_MINUTES * 60 * 4), players: players)
         
         XCTAssertGreaterThan(update.updatedPlayers[0].cash, players[0].cash, " cash")
         XCTAssertEqual(update.updatedPlayers[0].id, players[0].id, "Player.id should be the same after update.")


### PR DESCRIPTION
Model structures Player, Simulation and Improvement all had update() functions. These lead to confusion because their protocol extensions to Fluent models, add an update(on:) function. These have very different intentions and behavior. Therefore:

- player.update() was renamed to player.playerUpdate()
- improvement.update() was renamed to improvement.updateImprovement()
- simulation.update(::) was renamed to simulation.update(::)